### PR TITLE
Switch to using arc42 and c4 model for design doc

### DIFF
--- a/design/_report.qmd
+++ b/design/_report.qmd
@@ -2,39 +2,26 @@
 title: Design specification and architecture of Seedcase
 ---
 
-<!-- connects all docs and sends to Zenodo for each "release" -->
+<!-- Following [arc42](https://arc42.org) and [C4](https://c4model.com/) -->
 
-{{ include index.md }}
+{{ include introduction.qmd }}
 
-{{ include overview.md }}
+{{ include constraints.qmd }}
 
-{{ include use-cases.md }}
+{{ include context.qmd }}
 
-# User interaction and internal pathways
+{{ include solution-strategy.qmd }}
 
-<!-- NOTE: Orchestration? -->
+{{ include building-block-view.qmd }}
 
-{{ include pathways/data-input.md }}
+{{ include runtime-view.qmd }}
 
-{{ include pathways/data-discovery.md }}
+{{ include deployment-view.qmd }}
 
-{{ include pathways/knowledge-sharing.md }}
+{{ include cross-cutting-concepts.qmd }}
 
-{{ include pathways/admin.md }}
+{{ include architectural-decisions.qmd }}
 
-# Architecture of the layers
+{{ include quality-requirements.qmd}}
 
-{{ include architecture/frontend.md }}
-
-{{ include architecture/api.md }}
-
-{{ include architecture/backend.md }}
-
-# Security and privacy
-
-{{ include security.md }}
-
-# Requirements
-
-{{ include requirements.qmd }}
-
+{{ include risks.qmd }}


### PR DESCRIPTION
These are templates to follow when writing architecture documentation. This doesn't change what everyone is working on, just provides a structure for the document when we send it out for review. Merging right away.